### PR TITLE
fixed-itertool-imports

### DIFF
--- a/checksum/__init__.py
+++ b/checksum/__init__.py
@@ -21,7 +21,17 @@ import hashlib
 import re
 import itertools
 
+try:
+    from itertools import imap
+except ImportError:
+    # Python 3...
+    imap=map
 
+try:
+    from itertools import ifilterfalse
+except ImportError:
+    # Python 3...
+    ifilterfalse=itertools.filterfalse
 
 _HASH_MODE_DICT = {
     "md5": hashlib.md5,
@@ -29,8 +39,6 @@ _HASH_MODE_DICT = {
     "sha256": hashlib.sha256,
     "sha512": hashlib.sha512
 }
-
-
 
 def get_for_directory(
         dp,
@@ -54,15 +62,15 @@ def get_for_directory(
     hash_func = _HASH_MODE_DICT.get(hash_mode)
 
     root_dps_fns =      os.walk( dp, topdown=True )
-    root_dps_fns =      itertools.imap(         list,                  root_dps_fns )
+    root_dps_fns =      imap(         list,                  root_dps_fns )
     if filter_dots:
-        root_dps_fns =  itertools.ifilterfalse( _is_dot_root,           root_dps_fns )
-        root_dps_fns =  itertools.imap(         _filter_dot_fns,        root_dps_fns )
-    fps_lists =         itertools.imap(         _gen_fps,               root_dps_fns )
+        root_dps_fns =  ifilterfalse( _is_dot_root,           root_dps_fns )
+        root_dps_fns =  imap(         _filter_dot_fns,        root_dps_fns )
+    fps_lists =         imap(         _gen_fps,               root_dps_fns )
     fps =               itertools.chain(        *fps_lists )
-    fps =               itertools.ifilterfalse( filter_func,           fps )
-    file_handles =      itertools.imap(         _get_file_handle,      fps )
-    file_hash_digests = itertools.imap(         _get_file_hash_digest, file_handles, itertools.repeat(hash_func) )
+    fps =               ifilterfalse( filter_func,           fps )
+    file_handles =      imap(         _get_file_handle,      fps )
+    file_hash_digests = imap(         _get_file_hash_digest, file_handles, itertools.repeat(hash_func) )
     file_hash_digests = sorted( file_hash_digests )
     file_hash_digests = map(    _get_utf8_encoded, file_hash_digests )
 
@@ -123,7 +131,7 @@ def _is_dot_root( root_dps_fns ):
 
 
 def _filter_dot_fns( root_dps_fns ):
-    root_dps_fns[2] = itertools.ifilterfalse( lambda fn: fn.startswith('.'), root_dps_fns[2] )
+    root_dps_fns[2] = ifilterfalse( lambda fn: fn.startswith('.'), root_dps_fns[2] )
     return root_dps_fns
 
 

--- a/checksum/__init__.py
+++ b/checksum/__init__.py
@@ -25,13 +25,13 @@ import six
 try:
     from itertools import imap
 except ImportError:
-    # Python 3...
+    # Py3
     imap=map
 
 try:
     from itertools import ifilterfalse
 except ImportError:
-    # Python 3...
+    # Py3
     ifilterfalse=itertools.filterfalse
 
 _HASH_MODE_DICT = {
@@ -73,7 +73,7 @@ def get_for_directory(
     file_handles =      imap(         _get_file_handle,      fps )
     file_hash_digests = imap(         _get_file_hash_digest, file_handles, itertools.repeat(hash_func) )
     file_hash_digests = sorted( file_hash_digests )
-    file_hash_digests = list(imap(    _get_utf8_encoded, file_hash_digests ))
+    file_hash_digests = map(    _get_utf8_encoded, file_hash_digests )
 
     hash_ = _get_merged_hash( file_hash_digests, hash_func )
 
@@ -144,28 +144,22 @@ def _gen_fps( root_dps_fns ):
 
 def _get_utf8_encoded( hash_digest ):
     if six.PY2:
-        #print("Py2")
-        #print(hash_digest) # py2 print
-        return hash_digest.encode( "utf-8" ) # py2
+        return hash_digest.encode( 'utf-8' )
     if six.PY3:
-        #print("Py3")
-        hash_var = hash_digest.encode( "utf-8" )
-        #print(str(hash_var, 'utf-8')) # py3 print
-        return str(hash_var, 'utf-8') #py3
+        hash_encoded = hash_digest.encode( 'utf-8' )
+        return str(hash_encoded, 'utf-8')
 
 
 
 def _get_merged_hash(hash_digests, hashfunc):
+    result = hashfunc()
     if six.PY2:
-        result = hashfunc()
-        #print("py2 before map " + result.hexdigest())
         map( result.update, hash_digests )
-        #print(result.hexdigest()) # py2
     if six.PY3:
-        result = hashfunc()
-        #print("py3 before map " + str(result.hexdigest()))
-        map( result.update, hash_digests ) # I think issue is here is not updating
-        #print("merged " + str(result.hexdigest())) # py3
+        # map does not update result, even when provided an iterable object
+        #map( result.update, hash_digests )
+        for digest in hash_digests:
+            result.update(digest.encode('utf-8'))
     return result
 
 

--- a/checksum/__init__.py
+++ b/checksum/__init__.py
@@ -20,6 +20,7 @@ import os
 import hashlib
 import re
 import itertools
+import six
 
 try:
     from itertools import imap
@@ -72,7 +73,7 @@ def get_for_directory(
     file_handles =      imap(         _get_file_handle,      fps )
     file_hash_digests = imap(         _get_file_hash_digest, file_handles, itertools.repeat(hash_func) )
     file_hash_digests = sorted( file_hash_digests )
-    file_hash_digests = map(    _get_utf8_encoded, file_hash_digests )
+    file_hash_digests = list(imap(    _get_utf8_encoded, file_hash_digests ))
 
     hash_ = _get_merged_hash( file_hash_digests, hash_func )
 
@@ -142,13 +143,29 @@ def _gen_fps( root_dps_fns ):
 
 
 def _get_utf8_encoded( hash_digest ):
-    return hash_digest.encode( "utf-8" )
+    if six.PY2:
+        #print("Py2")
+        #print(hash_digest) # py2 print
+        return hash_digest.encode( "utf-8" ) # py2
+    if six.PY3:
+        #print("Py3")
+        hash_var = hash_digest.encode( "utf-8" )
+        #print(str(hash_var, 'utf-8')) # py3 print
+        return str(hash_var, 'utf-8') #py3
 
 
 
 def _get_merged_hash(hash_digests, hashfunc):
-    result = hashfunc()
-    map( result.update, hash_digests )
+    if six.PY2:
+        result = hashfunc()
+        #print("py2 before map " + result.hexdigest())
+        map( result.update, hash_digests )
+        #print(result.hexdigest()) # py2
+    if six.PY3:
+        result = hashfunc()
+        #print("py3 before map " + str(result.hexdigest()))
+        map( result.update, hash_digests ) # I think issue is here is not updating
+        #print("merged " + str(result.hexdigest())) # py3
     return result
 
 


### PR DESCRIPTION
Python3 had some changes in itertools:
This PR tries to import from python2 itertools, or pulls new functions with python3.

- itertools.imap is no longer in itertools, is just plain map
- itertools.ifilterfalse was changed to itertools.filterfalse

Tested with python 3.5.1, and retested with python 2.7.12:

```
import checksum

print(checksum.get_for_file("Blog-Github.txt"))
print(checksum.get_for_file("Blog-Github copy.txt"))
print(checksum.get_for_directory("/Users/terminalX/Documents/Python/utils/"))

```


```
python3 test.py
b'ae96c34252946bbd6921a4a220f5a3c5'
b'ae96c34252946bbd6921a4a220f5a3c5'
d41d8cd98f00b204e9800998ecf8427e
```

```
python2 __init__.py
ae96c34252946bbd6921a4a220f5a3c5
ae96c34252946bbd6921a4a220f5a3c5
cd4b5cfb9920a7ae4037f640f290695f
```